### PR TITLE
Useful Span-based methods for ByteString

### DIFF
--- a/csharp/src/Google.Protobuf/ByteString.cs
+++ b/csharp/src/Google.Protobuf/ByteString.cs
@@ -67,15 +67,6 @@ namespace Google.Protobuf
             {
                 return new ByteString(bytes);
             }
-
-            /// <summary>
-            /// Provides direct, unrestricted access to the bytes contained in this instance.
-            /// You must not modify or resize the byte array returned by this method.
-            /// </summary>
-            internal static byte[] GetBuffer(ByteString bytes)
-            {
-                return bytes.bytes;
-            }
         }
 
         /// <summary>
@@ -118,6 +109,12 @@ namespace Google.Protobuf
         {
             get { return Length == 0; }
         }
+
+        /// <summary>
+        /// Provides read-only access to the data of this <see cref="ByteString"/>.
+        /// No data is copied so this is the most efficient way of accessing.
+        /// </summary>
+        public ReadOnlySpan<byte> Span => new ReadOnlySpan<byte>(bytes);
 
         /// <summary>
         /// Converts this <see cref="ByteString"/> into a byte array.
@@ -217,6 +214,16 @@ namespace Google.Protobuf
             byte[] portion = new byte[count];
             ByteArray.Copy(bytes, offset, portion, 0, count);
             return new ByteString(portion);
+        }
+
+        /// <summary>
+        /// Constructs a <see cref="ByteString" /> from a read only span. The contents
+        /// are copied, so further modifications to the span will not
+        /// be reflected in the returned <see cref="ByteString" />.
+        /// </summary>
+        public static ByteString CopyFrom(ReadOnlySpan<byte> bytes)
+        {
+            return new ByteString(bytes.ToArray());
         }
 
         /// <summary>


### PR DESCRIPTION
- expose read-only view of ByteString contents
- enable construction of ByteString from ReadOnlySpan